### PR TITLE
Version related fixes

### DIFF
--- a/exwm-floating.el
+++ b/exwm-floating.el
@@ -31,7 +31,6 @@
 
 (defgroup exwm-floating nil
   "Floating."
-  :version "25.3"
   :group 'exwm)
 
 (defcustom exwm-floating-setup-hook nil

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -587,20 +587,10 @@ instead."
   (when (called-interactively-p 'any)
     (exwm-input--update-global-prefix-keys)))
 
-;; Putting (t . EVENT) into `unread-command-events' does not really work
-;; as documented for Emacs < 26.2.
-(eval-and-compile
-  (if (or (< emacs-major-version 26)
-          (and (= emacs-major-version 26)
-               (< emacs-minor-version 2)))
-      (defsubst exwm-input--unread-event (event)
-        (declare (indent defun))
-        (setq unread-command-events
-              (append unread-command-events (list event))))
-    (defsubst exwm-input--unread-event (event)
-      (declare (indent defun))
-      (setq unread-command-events
-            (append unread-command-events `((t . ,event)))))))
+(defsubst exwm-input--unread-event (event)
+  (declare (indent defun))
+  (setq unread-command-events
+        (append unread-command-events `((t . ,event)))))
 
 (defun exwm-input--mimic-read-event (event)
   "Process EVENT as if it were returned by `read-event'."

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -40,7 +40,6 @@
 
 (defgroup exwm-input nil
   "Input."
-  :version "25.3"
   :group 'exwm)
 
 (defcustom exwm-input-prefix-keys

--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -29,7 +29,6 @@
 
 (defgroup exwm-layout nil
   "Layout."
-  :version "25.3"
   :group 'exwm)
 
 (defcustom exwm-layout-auto-iconify t

--- a/exwm-manage.el
+++ b/exwm-manage.el
@@ -30,7 +30,6 @@
 
 (defgroup exwm-manage nil
   "Manage."
-  :version "25.3"
   :group 'exwm)
 
 (defcustom exwm-manage-finish-hook nil

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -56,7 +56,6 @@
 
 (defgroup exwm-randr nil
   "RandR."
-  :version "25.3"
   :group 'exwm)
 
 (defcustom exwm-randr-refresh-hook nil

--- a/exwm-systemtray.el
+++ b/exwm-systemtray.el
@@ -57,7 +57,6 @@
 
 (defgroup exwm-systemtray nil
   "System tray."
-  :version "25.3"
   :group 'exwm)
 
 (defcustom exwm-systemtray-height nil

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -31,7 +31,6 @@
 
 (defgroup exwm-workspace nil
   "Workspace."
-  :version "25.3"
   :group 'exwm)
 
 (defcustom exwm-workspace-switch-hook nil

--- a/exwm.el
+++ b/exwm.el
@@ -5,7 +5,7 @@
 ;; Author: Chris Feng <chris.w.feng@gmail.com>
 ;; Maintainer: Adrián Medraño Calvo <adrian@medranocalvo.com>
 ;; Version: 0.28
-;; Package-Requires: ((emacs "26.1") (xelb "0.18"))
+;; Package-Requires: ((emacs "27.1") (xelb "0.18"))
 ;; Keywords: unix
 ;; URL: https://github.com/ch11ng/exwm
 

--- a/exwm.el
+++ b/exwm.el
@@ -79,7 +79,6 @@
 (defgroup exwm nil
   "Emacs X Window Manager."
   :tag "EXWM"
-  :version "25.3"
   :group 'applications
   :prefix "exwm-")
 


### PR DESCRIPTION
I suggested in https://github.com/ch11ng/exwm/pull/935#discussion_r1446362095 to bump the Emacs dependency to 27.1. These days, 27.1 is widely available (for users and testers, 28 not yet). It seems like a reasonable minimal dependency. We can also remove a tiny bit of code, specific to Emacs 26. How do you feel about this?