### PR TITLE
Use '=' instead of 'eq' to compare numbers.

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -156,7 +156,8 @@ See variable `exwm-layout-auto-iconify'."
   (with-current-buffer (exwm--id->buffer id)
     (unless (or (exwm-layout--iconic-state-p)
                 (and exwm--floating-frame
-                     (eq 4294967295. exwm--desktop)))
+                     exwm--desktop
+                     (= 4294967295. exwm--desktop)))
       (exwm--log "Hide #x%x" id)
       (when exwm--floating-frame
         (let* ((container (frame-parameter exwm--floating-frame

--- a/exwm.el
+++ b/exwm.el
@@ -176,7 +176,7 @@ Argument XWIN contains the X window of the `exwm-mode' buffer."
       (when reply
         (setq desktop (slot-value reply 'value))
         (cond
-         ((eq desktop 4294967295.)
+         ((and desktop (= desktop 4294967295.))
           (unless (or (not exwm--floating-frame)
                       (eq exwm--frame exwm-workspace--current)
                       (and exwm--desktop


### PR DESCRIPTION
* exwm.el (exwm--update-desktop): use `=` instead of `eq` for numeric comparison.
* exwm-layout.el (exwm-layout--hide):
  Use `=` instead of `eq` for numeric comparison.