### PR TITLE
Use color-values instead of x-color-values

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -206,7 +206,7 @@ If FRAME is null, use selected frame."
   "Convert COLOR to PIXEL (index in TrueColor colormap)."
   (when (and color
              (eq (x-display-visual-class) 'true-color))
-    (let ((rgb (x-color-values color)))
+    (let ((rgb (color-values color)))
       (logior (ash (ash (pop rgb) -8) 16)
               (ash (ash (pop rgb) -8) 8)
               (ash (pop rgb) -8)))))


### PR DESCRIPTION
* exwm-core.el (exwm--color->pixel): Use `color-values` (introduced in Emacs 21) instead of `x-color-values` (deprecated in Emacs 30).