### PR TITLE
Add global minor modes for EXWM's features

### DIFF
--- a/exwm-background.el
+++ b/exwm-background.el
@@ -43,7 +43,7 @@
   :initialize #'custom-initialize-default
   :set (lambda (symbol value)
          (set-default-toplevel-value symbol value)
-         (exwm-background--update)))
+         (when (bound-and-true-p exwm-background-mode) (exwm-background--update))))
 
 (defconst exwm-background--properties '("_XROOTPMAP_ID" "_XSETROOT_ID" "ESETROOT_PMAP_ID")
   "The background properties to set.
@@ -188,11 +188,16 @@ may kill this connection when they replace it.")
         exwm-background--connection nil
         exwm-background--atoms nil))
 
+;;;###autoload(autoload 'exwm-background-mode "exwm-background" nil t)
+(exwm--define-global-minor-mode background
+  "Global minor mode for toggling EXWM background support.")
+
 (defun exwm-background-enable ()
   "Enable background support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-background--init)
-  (add-hook 'exwm-exit-hook #'exwm-background--exit))
+  (add-hook 'exwm-init-hook #'exwm-background-mode)
+  (add-hook 'exwm-exit-hook (apply-partially #'exwm-background-mode -1))
+  (when exwm--connection (exwm-background-mode)))
+(make-obsolete #'exwm-background-enable "Use `exwm-background-mode' instead." "0.40")
 
 (provide 'exwm-background)
 

--- a/exwm-core.el
+++ b/exwm-core.el
@@ -408,6 +408,28 @@ One of `line-mode' or `char-mode'.")
         right-fringe-width 0
         vertical-scroll-bar nil))
 
+(defmacro exwm--define-global-minor-mode (name doc &optional init exit)
+  "Define global minor mode named exwm-NAME-mode.
+EXWM's init-hook and exit-hook are modified to call INIT and EXIT functions.
+If an X connection exists, the mode is immediately enabled or disabled."
+  (declare (indent 1) (debug t))
+  (let ((mode (intern (format "exwm-%s-mode" name)))
+        (init (or init (intern (format "exwm-%s--init" name))))
+        (exit (or exit (intern (format "exwm-%s--exit" name)))))
+    `(define-minor-mode ,mode
+       ,doc
+       :global t
+       :group 'exwm
+       (exwm--log)
+       (cond
+        (,mode
+         (add-hook 'exwm-init-hook #',init)
+         (add-hook 'exwm-exit-hook #',exit)
+         (when exwm--connection (,init)))
+        (t
+         (remove-hook 'exwm-init-hook #',init)
+         (remove-hook 'exwm-exit-hook #',exit)
+         (when exwm--connection (,exit)))))))
 
 
 (provide 'exwm-core)

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -356,11 +356,16 @@ Refresh when any RandR 1.5 monitor changes."
   (exwm--log)
   (remove-hook 'exwm-workspace-list-change-hook #'exwm-randr-refresh))
 
+;;;###autoload(autoload 'exwm-randr-mode "exwm-randr" nil t)
+(exwm--define-global-minor-mode randr
+  "Global minor mode for toggling EXWM RandR support.")
+
 (defun exwm-randr-enable ()
   "Enable RandR support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-randr--init)
-  (add-hook 'exwm-exit-hook #'exwm-randr--exit))
+  (add-hook 'exwm-init-hook #'exwm-randr-mode)
+  (add-hook 'exwm-exit-hook (apply-partially #'exwm-randr-mode -1))
+  (when exwm--connection (exwm-randr-mode)))
+(make-obsolete #'exwm-randr-enable "Use `exwm-randr-mode' instead." "0.40")
 
 
 

--- a/exwm-systemtray.el
+++ b/exwm-systemtray.el
@@ -87,7 +87,8 @@ TrueColor-24\" can be used to force Emacs to use 24-bit depth."
 using 32-bit depth.  Using `workspace-background' instead.")
            (setq value 'workspace-background))
          (set-default symbol value)
-         (when (and exwm-systemtray--connection
+         (when (and (bound-and-true-p exwm-systemtray-mode)
+                    exwm-systemtray--connection
                     exwm-systemtray--embedder-window)
            ;; Change the background color for embedder.
            (exwm-systemtray--set-background-color)
@@ -679,11 +680,16 @@ Argument DATA contains the raw event data."
     (when (boundp 'exwm-randr-refresh-hook)
       (remove-hook 'exwm-randr-refresh-hook #'exwm-systemtray--refresh-all))))
 
+;;;###autoload(autoload 'exwm-systemtray-mode "exwm-systemtray" nil t)
+(exwm--define-global-minor-mode systemtray
+  "Global minor mode for toggling EXWM systemtray.")
+
 (defun exwm-systemtray-enable ()
   "Enable system tray support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-systemtray--init)
-  (add-hook 'exwm-exit-hook #'exwm-systemtray--exit))
+  (add-hook 'exwm-init-hook #'exwm-systemtray-mode)
+  (add-hook 'exwm-exit-hook (apply-partially #'exwm-systemtray-mode -1))
+  (when exwm--connection (exwm-systemtray-mode)))
+(make-obsolete #'exwm-systemtray-enable "Use `exwm-systemtray-mode' instead." "0.40")
 
 
 

--- a/exwm-xim.el
+++ b/exwm-xim.el
@@ -797,11 +797,16 @@ Such event would be received when the client window is destroyed."
   (xcb:disconnect exwm-xim--conn)
   (setq exwm-xim--conn nil))
 
+;;;###autoload(autoload 'exwm-xim-mode "exwm-xim" nil t)
+(exwm--define-global-minor-mode xim
+  "Global minor mode for toggling EXWM XIM support.")
+
 (defun exwm-xim-enable ()
   "Enable XIM support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-xim--init)
-  (add-hook 'exwm-exit-hook #'exwm-xim--exit))
+  (add-hook 'exwm-init-hook #'exwm-xim-mode)
+  (add-hook 'exwm-exit-hook (apply-partially #'exwm-xim-mode -1))
+  (when exwm--connection (exwm-xim-mode)))
+(make-obsolete #'exwm-xim-enable "Use `exwm-xim-mode' instead." "0.40")
 
 
 

--- a/exwm-xsettings.el
+++ b/exwm-xsettings.el
@@ -67,7 +67,8 @@
 
 SYMBOL is the setting being updated and VALUE is the new value."
   (set-default-toplevel-value symbol value)
-  (exwm-xsettings--update-settings))
+  (when (bound-and-true-p exwm-xsettings-mode)
+    (exwm-xsettings--update-settings)))
 
 (defgroup exwm-xsettings nil
   "XSETTINGS."
@@ -325,11 +326,16 @@ SERIAL is a sequence number."
           exwm-xsettings--XSETTINGS_S0-atom nil
           exwm-xsettings--selection-owner-window nil)))
 
+;;;###autoload(autoload 'exwm-xsettings-mode "exwm-xsettings" nil t)
+(exwm--define-global-minor-mode xsettings
+  "Global minor mode for toggling EXWM Xsettings support.")
+
 (defun exwm-xsettings-enable ()
   "Enable xsettings support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-xsettings--init)
-  (add-hook 'exwm-exit-hook #'exwm-xsettings--exit))
+  (add-hook 'exwm-init-hook #'exwm-xsettings-mode)
+  (add-hook 'exwm-exit-hook (apply-partially #'exwm-xsettings-mode -1))
+  (when exwm--connection (exwm-xsettings-mode)))
+(make-obsolete #'exwm-xsettings-enable "Use `exwm-xsettings-mode' instead." "0.40")
 
 (provide 'exwm-xsettings)
 


### PR DESCRIPTION
* exwm-systemtray.el (exwm-systemtray-mode): Global minor mode for toggling display of the systemtray.