### PR TITLE
Add global minor modes for features (take two)

### DIFF
--- a/exwm-background.el
+++ b/exwm-background.el
@@ -34,6 +34,19 @@
 
 (require 'exwm-core)
 
+;;;###autoload
+(define-minor-mode exwm-background-mode
+  "Toggle EXWM background support."
+  :global t
+  :group 'exwm
+  (exwm--global-minor-mode-body background))
+
+;;;###autoload
+(defun exwm-background-enable ()
+  "Enable EXWM background support."
+  (exwm-background-mode 1))
+(make-obsolete #'exwm-background-enable "Use `exwm-background-mode' instead." "0.40")
+
 (defcustom exwm-background-color nil
   "Background color for Xorg."
   :type '(choice
@@ -43,7 +56,7 @@
   :initialize #'custom-initialize-default
   :set (lambda (symbol value)
          (set-default-toplevel-value symbol value)
-         (exwm-background--update)))
+         (when exwm-background-mode (exwm-background--update))))
 
 (defconst exwm-background--properties '("_XROOTPMAP_ID" "_XSETROOT_ID" "ESETROOT_PMAP_ID")
   "The background properties to set.
@@ -187,12 +200,6 @@ may kill this connection when they replace it.")
   (setq exwm-background--pixmap nil
         exwm-background--connection nil
         exwm-background--atoms nil))
-
-(defun exwm-background-enable ()
-  "Enable background support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-background--init)
-  (add-hook 'exwm-exit-hook #'exwm-background--exit))
 
 (provide 'exwm-background)
 

--- a/exwm-core.el
+++ b/exwm-core.el
@@ -408,6 +408,26 @@ One of `line-mode' or `char-mode'.")
         right-fringe-width 0
         vertical-scroll-bar nil))
 
+(defmacro exwm--global-minor-mode-body (name &optional init exit)
+  "Define EXWM namespaced global minor mode with NAME.
+EXWM's init-hook and exit-hook are modified to call INIT and EXIT functions.
+If an X connection exists, the mode is immediately enabled or disabled."
+  (declare (indent 1) (debug t))
+  (let* ((mode (intern (format "exwm-%s-mode" name)))
+         (init (or init (intern (format "exwm-%s--init" name))))
+         (exit (or exit (intern (format "exwm-%s--exit" name)))))
+    `(progn
+       (exwm--log)
+       (cond
+        (,mode
+         (add-hook 'exwm-init-hook #',init)
+         (add-hook 'exwm-exit-hook #',exit)
+         (when exwm--connection (,init)))
+        (t
+         (remove-hook 'exwm-init-hook #',init)
+         (remove-hook 'exwm-exit-hook #',exit)
+         (when exwm--connection (,exit)))))))
+
 
 
 (provide 'exwm-core)

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -356,11 +356,18 @@ Refresh when any RandR 1.5 monitor changes."
   (exwm--log)
   (remove-hook 'exwm-workspace-list-change-hook #'exwm-randr-refresh))
 
+;;;###autoload
+(define-minor-mode exwm-randr-mode
+  "Toggle EXWM randr support."
+  :global t
+  :group 'exwm
+  (exwm--global-minor-mode-body randr))
+
+;;;###autoload
 (defun exwm-randr-enable ()
-  "Enable RandR support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-randr--init)
-  (add-hook 'exwm-exit-hook #'exwm-randr--exit))
+  "Enable EXWM RandR support."
+  (exwm-randr-mode 1))
+(make-obsolete #'exwm-randr-enable "Use `exwm-randr-mode' instead." "0.40")
 
 
 

--- a/exwm-systemtray.el
+++ b/exwm-systemtray.el
@@ -50,6 +50,19 @@
   "System tray."
   :group 'exwm)
 
+;;;###autoload
+(define-minor-mode exwm-systemtray-mode
+  "Toggle EXWM systemtray support."
+  :global t
+  :group 'exwm
+  (exwm--global-minor-mode-body systemtray))
+
+;;;###autoload
+(defun exwm-systemtray-enable ()
+  "Enable EXWM systemtray support."
+  (exwm-systemtray-mode 1))
+(make-obsolete #'exwm-systemtray-enable "Use `exwm-systemtray-mode' instead." "0.40")
+
 (defcustom exwm-systemtray-height nil
   "System tray height.
 
@@ -87,7 +100,8 @@ TrueColor-24\" can be used to force Emacs to use 24-bit depth."
 using 32-bit depth.  Using `workspace-background' instead.")
            (setq value 'workspace-background))
          (set-default symbol value)
-         (when (and exwm-systemtray--connection
+         (when (and exwm-systemtray-mode
+                    exwm-systemtray--connection
                     exwm-systemtray--embedder-window)
            ;; Change the background color for embedder.
            (exwm-systemtray--set-background-color)
@@ -678,12 +692,6 @@ Argument DATA contains the raw event data."
     (remove-hook 'tool-bar-mode-hook #'exwm-systemtray--refresh-all)
     (when (boundp 'exwm-randr-refresh-hook)
       (remove-hook 'exwm-randr-refresh-hook #'exwm-systemtray--refresh-all))))
-
-(defun exwm-systemtray-enable ()
-  "Enable system tray support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-systemtray--init)
-  (add-hook 'exwm-exit-hook #'exwm-systemtray--exit))
 
 
 

--- a/exwm-xim.el
+++ b/exwm-xim.el
@@ -797,11 +797,18 @@ Such event would be received when the client window is destroyed."
   (xcb:disconnect exwm-xim--conn)
   (setq exwm-xim--conn nil))
 
+;;;###autoload
+(define-minor-mode exwm-xim-mode
+  "Toggle EXWM XIM support."
+  :global t
+  :group 'exwm
+  (exwm--global-minor-mode-body xim))
+
+;;;###autoload
 (defun exwm-xim-enable ()
-  "Enable XIM support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-xim--init)
-  (add-hook 'exwm-exit-hook #'exwm-xim--exit))
+  "Enable EXWM XIM support."
+  (exwm-xim-mode 1))
+(make-obsolete #'exwm-xim-enable "Use `exwm-xim-mode' instead." "0.40")
 
 
 

--- a/exwm-xsettings.el
+++ b/exwm-xsettings.el
@@ -58,6 +58,19 @@
 (defvar exwm-xsettings--selection-owner-window nil)
 (defvar exwm-xsettings--serial 0)
 
+;;;###autoload
+(define-minor-mode exwm-xsettings-mode
+  "Toggle EXWM xsettings support."
+  :global t
+  :group 'exwm
+  (exwm--global-minor-mode-body xsettings))
+
+;;;###autoload
+(defun exwm-xsettings-enable ()
+  "Enable EXWM xsettings support."
+  (exwm-xsettings-mode 1))
+(make-obsolete #'exwm-xsettings-enable "Use `exwm-xsettings-mode' instead." "0.40")
+
 (defun exwm-xsettings--rgba-match (_widget value)
   "Return t if VALUE is a valid RGBA color."
   (and (numberp value) (<= 0 value 1)))
@@ -67,7 +80,7 @@
 
 SYMBOL is the setting being updated and VALUE is the new value."
   (set-default-toplevel-value symbol value)
-  (exwm-xsettings--update-settings))
+  (when exwm-xsettings-mode (exwm-xsettings--update-settings)))
 
 (defgroup exwm-xsettings nil
   "XSETTINGS."
@@ -324,12 +337,6 @@ SERIAL is a sequence number."
           exwm-xsettings--XSETTINGS_SETTINGS-atom nil
           exwm-xsettings--XSETTINGS_S0-atom nil
           exwm-xsettings--selection-owner-window nil)))
-
-(defun exwm-xsettings-enable ()
-  "Enable xsettings support for EXWM."
-  (exwm--log)
-  (add-hook 'exwm-init-hook #'exwm-xsettings--init)
-  (add-hook 'exwm-exit-hook #'exwm-xsettings--exit))
 
 (provide 'exwm-xsettings)
 


### PR DESCRIPTION
* exwm-core.el (exwm--define-global-minor-mode): Macro for arranging EXWM mode hooks, deprecating enabler functions, logging.
* exwm-background.el: Add global mode definition, autoloads (exwm-background-enable): remove
* exwm-randr.el (randr): as above (exwm-randr-enable): as above
* exwm-systemtray.el (systemtray): as above (exwm-systemtray-mode): as above
* exwm-xim.el (xim): as above (exwm-xim-enable): as above
* exwm-xsettings.el (xsettings): as above (exwm-xsettings-enable): as above