### PR TITLE
satisfy checkdoc

### DIFF
--- a/exwm-background.el
+++ b/exwm-background.el
@@ -156,10 +156,12 @@ may kill this connection when they replace it.")
   (xcb:flush exwm-background--connection))
 
 (defun exwm-background--connected-p ()
+  "Return t if a live background connection process exists and is connected."
   (and exwm-background--connection
        (process-live-p (slot-value exwm-background--connection 'process))))
 
 (defun exwm-background--connect ()
+  "Establish background Pixmap connection."
   (unless (exwm-background--connected-p)
     (setq exwm-background--connection (xcb:connect))
     ;;prevent query message on exit

--- a/exwm-core.el
+++ b/exwm-core.el
@@ -38,12 +38,12 @@
   :group 'exwm)
 
 (defcustom exwm-debug-log-time-function #'exwm-debug-log-uptime
-  "Function used for generating timestamps in `exwm-debug' logs.
+  "Function used for generating timestamps in debug log.
 
 Here are some predefined candidates:
 `exwm-debug-log-uptime': Display the uptime of this Emacs instance.
 `exwm-debug-log-time': Display time of day.
-`nil': Disable timestamp."
+nil: Disable timestamp."
   :type `(choice (const :tag "Emacs uptime" ,#'exwm-debug-log-uptime)
                  (const :tag "Time of day" ,#'exwm-debug-log-time)
                  (const :tag "Off" nil)
@@ -98,14 +98,15 @@ Here are some predefined candidates:
 (declare-function exwm-workspace-switch "exwm-workspace.el"
                   (frame-or-index &optional force))
 
-(define-minor-mode exwm-debug
+(define-minor-mode exwm-debug-mode
   "Debug-logging enabled if non-nil."
   :global t
   :group 'exwm-debug)
+(define-obsolete-function-alias 'exwm-debug 'exwm-debug-mode "0.30")
 
 (defmacro exwm--debug (&rest forms)
-  "Evaluate FORMS if mode `exwm-debug' is active."
-  (when exwm-debug `(progn ,@forms)))
+  "Evaluate FORMS if `exwm-debug-mode' is active."
+  (when exwm-debug-mode `(progn ,@forms)))
 
 (defmacro exwm--log (&optional format-string &rest objects)
   "Emit a message prepending the name of the function being executed.
@@ -113,7 +114,7 @@ Here are some predefined candidates:
 FORMAT-STRING is a string specifying the message to output, as in
 `format'.  The OBJECTS arguments specify the substitutions."
   (unless format-string (setq format-string ""))
-  `(when exwm-debug
+  `(when exwm-debug-mode
      (xcb-debug:message ,(concat "%s%s:\t" format-string "\n")
                         (if exwm-debug-log-time-function
                             (funcall exwm-debug-log-time-function)
@@ -285,7 +286,7 @@ One of `line-mode' or `char-mode'.")
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-c\C-d\C-l" #'xcb-debug:clear)
     (define-key map "\C-c\C-d\C-m" #'xcb-debug:mark)
-    (define-key map "\C-c\C-d\C-t" #'exwm-debug)
+    (define-key map "\C-c\C-d\C-t" #'exwm-debug-mode)
     (define-key map "\C-c\C-f" #'exwm-layout-set-fullscreen)
     (define-key map "\C-c\C-h" #'exwm-floating-hide)
     (define-key map "\C-c\C-k" #'exwm-input-release-keyboard)

--- a/exwm-floating.el
+++ b/exwm-floating.el
@@ -125,13 +125,14 @@ This hook runs in the context of the corresponding buffer."
 (declare-function exwm-workspace--update-offsets "exwm-workspace.el" ())
 (declare-function exwm-workspace--workarea "exwm-workspace.el" (frame))
 
-(defun exwm-floating--set-allowed-actions (id tilling)
-  "Set _NET_WM_ALLOWED_ACTIONS."
+(defun exwm-floating--set-allowed-actions (id tiled-p)
+  "Set _NET_WM_ALLOWED_ACTIONS for window with ID.
+If TILED-P is non-nil, set actions for tiled window."
   (exwm--log "#x%x" id)
   (xcb:+request exwm--connection
       (make-instance 'xcb:ewmh:set-_NET_WM_ALLOWED_ACTIONS
                      :window id
-                     :data (if tilling
+                     :data (if tiled-p
                                (vector xcb:Atom:_NET_WM_ACTION_MINIMIZE
                                        xcb:Atom:_NET_WM_ACTION_FULLSCREEN
                                        xcb:Atom:_NET_WM_ACTION_CHANGE_DESKTOP
@@ -466,7 +467,9 @@ This hook runs in the context of the corresponding buffer."
     (select-frame-set-input-focus exwm-workspace--current)))
 
 (defun exwm-floating--start-moveresize (id &optional type)
-  "Start move/resize."
+  "Start move/resize for window with ID.
+When non-nil, TYPE indicates the type of move/resize.
+Float resizing is stopped when TYPE is nil."
   (exwm--log "#x%x" id)
   (let ((buffer-or-id (or (exwm--id->buffer id) id))
         frame container-or-id x y width height cursor)
@@ -672,7 +675,7 @@ This hook runs in the context of the corresponding buffer."
     (setq exwm-floating--moveresize-calculate nil)))
 
 (defun exwm-floating--do-moveresize (data _synthetic)
-  "Perform move/resize."
+  "Perform move/resize on floating window with DATA."
   (when exwm-floating--moveresize-calculate
     (let* ((obj (make-instance 'xcb:MotionNotify))
            result value-mask x y width height buffer-or-id container-or-id)

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -264,7 +264,7 @@ In a mirroring setup some monitors overlap and should be treated as one."
       (run-hooks 'exwm-randr-refresh-hook))))
 
 (defun exwm-randr--on-ScreenChangeNotify (data _synthetic)
-  "Handle `ScreenChangeNotify' event.
+  "Handle `ScreenChangeNotify' event with DATA.
 
 Run `exwm-randr-screen-change-hook' (usually user scripts to configure RandR)."
   (exwm--log)
@@ -276,7 +276,7 @@ Run `exwm-randr-screen-change-hook' (usually user scripts to configure RandR)."
         (run-hooks 'exwm-randr-screen-change-hook)))))
 
 (defun exwm-randr--on-Notify (data _synthetic)
-  "Handle `CrtcChangeNotify' and `OutputChangeNotify' events.
+  "Handle `CrtcChangeNotify' and `OutputChangeNotify' events with DATA.
 
 Refresh when any CRTC/output changes."
   (exwm--log)
@@ -296,7 +296,7 @@ Refresh when any CRTC/output changes."
             (setq exwm-randr--last-timestamp timestamp)))))))
 
 (defun exwm-randr--on-ConfigureNotify (data _synthetic)
-  "Handle `ConfigureNotify' event.
+  "Handle `ConfigureNotify' event with DATA.
 
 Refresh when any RandR 1.5 monitor changes."
   (exwm--log)

--- a/exwm-xim.el
+++ b/exwm-xim.el
@@ -269,7 +269,7 @@ this client."
       (xcb:flush exwm-xim--conn))))
 
 (cl-defun exwm-xim--on-ClientMessage (data _synthetic)
-  "Handle ClientMessage event on IMS communication window (request).
+  "Handle ClientMessage event DATA on IMS communication window (request).
 
 Such events would be received when clients request for _XIM_PROTOCOL.
 The actual XIM request is in client message data or a property."

--- a/exwm.el
+++ b/exwm.el
@@ -139,7 +139,7 @@ After this time, the server will be killed.")
   "Restart EXWM."
   (interactive)
   (exwm--log)
-  (when (exwm--confirm-kill-emacs "Restart?" 'no-check)
+  (when (exwm--confirm-kill-emacs "Restart" 'no-check)
     (let* ((attr (process-attributes (emacs-pid)))
            (args (cdr (assq 'args attr)))
            (ppid (cdr (assq 'ppid attr)))
@@ -976,7 +976,10 @@ FRAME, if given, indicates the X display EXWM should manage."
 
 ;;;###autoload
 (defun exwm-enable (&optional undo)
-  "Enable/Disable EXWM."
+  "Enable/Disable EXWM.
+Optional argument UNDO may be either of the following symbols:
+- `undo' prevents reinitialization.
+- `undo-all' attempts to revert all hooks and advice."
   (exwm--log "%s" undo)
   (pcase undo
     (`undo                              ;prevent reinitialization
@@ -1062,7 +1065,7 @@ FUNCTION is the function to be evaluated, ARGS are the arguments."
   ;; This is invoked instead of `save-buffers-kill-emacs' (C-x C-c) on client
   ;; frames.
   (if (exwm--terminal-p)
-      (exwm--confirm-kill-emacs "Kill terminal?")
+      (exwm--confirm-kill-emacs "Kill terminal")
     t))
 
 (defun exwm--confirm-kill-emacs (prompt &optional force)
@@ -1087,7 +1090,7 @@ If FORCE is any other non-nil value, force killing of Emacs."
             (`break (y-or-n-p prompt))
             (x x)))
          (t
-          (yes-or-no-p (format "[EXWM] %d X window(s) will be destroyed.  %s"
+          (yes-or-no-p (format "[EXWM] %d X window(s) will be destroyed.  %s?"
                                (length exwm--id-buffer-alist) prompt))))
     ;; Run `kill-emacs-hook' (`server-force-stop' excluded) before Emacs
     ;; frames are unmapped so that errors (if any) can be visible.


### PR DESCRIPTION
* exwm-background.el (exwm-background--connected-p): Add docstring. (exwm-background--connect): Add docstring.
* exwm-core.el (exwm-debug-log-time-function): (exwm-debug): Rename to exwm-debug-mode; define obsolete alias for old name. (exwm--debug): Update docstring to reflect above name change. (exwm--log): condition on exwm-debug-mode
(exwm-mode-map): update exwm-debug-mode binding
* exwm-floating.el (exwm-floating--set-allowed-actions): Rename TILLING parameter to TILED-P; update docstring. (exwm-floating--start-moveresize): Add parameters to docstring. (exwm-floating--do-moveresize): Add parameter to docstring.
* exwm-input.el (exwm-input-prefix-keys): Remove embedded keybinding from docstring. (exwm-input--on-PropertyNotify): Add parameter to docstring. (exwm-input--on-EnterNotify): Add parameter to docstring. (exwm-input--on-keysyms-update): Add docstring.
(exwm-input--set-active-window): Add parameter to docstring. (exwm-input--on-ButtonPress): Add parameter to docstring. (exwm-input--on-KeyPress): Add parameter to docstring. (exwm-input--on-CreateNotify): Add parameter to docstring. (exwm-input--grab-global-prefix-keys): Add docstring. (exwm-input--set-key): Add docstring.
(exwm-input-set-key): Add parameter to docstring.
(exwm-input--unread-event): Add docstring.
(exwm-input--translate): Add docstring.
(exwm-input--cache-event): Add parameter to docstring. (exwm-input--on-KeyPress-line-mode): Rename parameter; add parameter to docstring. (exwm-input--on-KeyPress-char-mode): Rename parameter; add parameter to docstring. (exwm-input-grab-keyboard): Add parameter to docstring. (exwm-input-release-keyboard): Add parameter to docstring. (exwm-input-toggle-keyboard): Add parameter to docstring. (exwm-input-send-next-key): Rename parameter; mention limit in docstring. (exwm-input--set-simulation-keys): Rename parameter; add parameter to docstring. (exwm-input--read-keys): Add docstring.
(exwm-input-set-simulation-key): Add parameters to docstring. (exwm-input-send-simulation-key): Rename parameter; add parameter to docstring.
* exwm-randr.el (exwm-randr--on-ScreenChangeNotify): Add parameter to docstring. (exwm-randr--on-Notify): Add parameter to docstring. (exwm-randr--on-ConfigureNotify): Add parameter to docstring.
* exwm-xim.el (exwm-xim--on-ClientMessage): Add parameter to docstring.
* exwm.el (exwm-restart): Remove question mark from prompt arg (exwm-enable): Remove question mark from prompt arg; add parameter to docstring. (exwm--confirm-kill-terminal): Remove question mark from prompt arg. (exwm--confirm-kill-emacs): Ensure prompt ends in question mark.