### PR TITLE
Fix app shortcuts in fullscreen

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -211,7 +211,8 @@ See variable `exwm-layout-auto-iconify'."
     (exwm-layout--set-ewmh-state exwm--id)
     (xcb:flush exwm--connection)
     (set-window-dedicated-p (get-buffer-window) t)
-    (exwm-input--release-keyboard exwm--id)))
+    (when (eq 'char-mode exwm--selected-input-mode)
+      (exwm-input--release-keyboard exwm--id))))
 
 ;;;###autoload
 (cl-defun exwm-layout-unset-fullscreen (&optional id)


### PR DESCRIPTION
Hi,

Here is a patch that I have for some times now into my `init.el`.  It is based on a patch I found here: https://github.com/ch11ng/exwm/issues/786.

### What does it fix? 

When using an application that you can toggle to fullscreen (for instance `mpv` with `f` shortcut), you are not able to use any of the application shortcuts after that (even untoggling fullscreen).  This patch fixes this.

Thanks.