### PR TITLE
Disable splitting of floating frames

### DIFF
--- a/exwm-floating.el
+++ b/exwm-floating.el
@@ -351,6 +351,8 @@ If TILED-P is non-nil, set actions for tiled window."
       (set-window-buffer window (current-buffer)) ;this changes current buffer
       (add-hook 'window-configuration-change-hook #'exwm-layout--refresh)
       (set-window-dedicated-p window t)
+      (set-window-parameter window 'split-window
+                            (lambda (&rest _) (user-error "Floating window cannot be split")))
       (exwm-layout--show id window))
     (with-current-buffer (exwm--id->buffer id)
       (if (exwm-layout--iconic-state-p id)


### PR DESCRIPTION
Previously, floating frames were configured to never automatically split, but they could be manually split (usually by accident).

* exwm-floating.el (exwm-floating--set-floating): disable splitting of floating windows by setting a the `split-window' window parameter to a function that always throws an error.