### PR TITLE
Disable position indicator in EXWM buffers

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -402,6 +402,8 @@ One of `line-mode' or `char-mode'.")
   ;; Redirect events when executing keyboard macros.
   (push `(executing-kbd-macro . ,exwm--kmacro-map)
         minor-mode-overriding-map-alist)
+  ;; Disable any mode-line position indicators for the buffer, they're nonsensical in exwm-mode.
+  (setq-local mode-line-position nil)
   (setq mode-name '(:eval (exwm--mode-name))
         buffer-read-only t
         cursor-type nil


### PR DESCRIPTION
* exwm-core.el (exwm-mode): disable the position indicator in EXWM buffer mode-lines.