### PR TITLE
Disable irrelevant mode-line  elements in EXWM buffers

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -402,6 +402,7 @@ One of `line-mode' or `char-mode'.")
   ;; Redirect events when executing keyboard macros.
   (push `(executing-kbd-macro . ,exwm--kmacro-map)
         minor-mode-overriding-map-alist)
+  (make-local-variable 'mode-line-position)
   (setq mode-name '(:eval (exwm--mode-name))
         buffer-read-only t
         cursor-type nil
@@ -409,7 +410,11 @@ One of `line-mode' or `char-mode'.")
         right-margin-width nil
         left-fringe-width 0
         right-fringe-width 0
-        vertical-scroll-bar nil))
+        vertical-scroll-bar nil
+        mode-line-position nil
+        mode-line-modified nil
+        mode-line-mule-info nil
+        mode-line-remote nil))
 
 (defmacro exwm--global-minor-mode-body (name &optional init exit)
   "Global minor mode body for mode with NAME.


### PR DESCRIPTION
* exwm-core (exwm-mode): disable mode-line-position, mode-line-modified, mode-line-mule-info, and mode-line-remote in EXWM buffers.