### PR TITLE
Avoid sometimes selecting killed buffers

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -385,6 +385,7 @@ If FRAME is nil, refresh layout of selected frame."
                                     (car-safe (window-prev-buffers window)))))
                   (and
                    prev-buffer
+                   (buffer-live-p prev-buffer)
                    (with-current-buffer prev-buffer
                      (derived-mode-p 'exwm-mode))
                    (push prev-buffer covered-buffers)))))))))


### PR DESCRIPTION
I am unable to reliably reproduce this, but occasionally, `window-prev-buffers` returns a killed buffer. Then, when EXWM tries to switch to it, it gives an error, and workspace switching locks up.