### PR TITLE
Remove exwm-input--during-command logic

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -306,7 +306,6 @@ One of `line-mode' or `char-mode'.")
         (interactive)
         (cond
          ((or exwm-input-line-mode-passthrough
-              ;; Do not test `exwm-input--during-command'.
               (active-minibuffer-window)
               (memq last-input-event exwm-input--global-prefix-keys)
               (memq last-input-event exwm-input-prefix-keys)

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -134,7 +134,6 @@ Please manually run the hook `exwm-workspace-list-change-hook' afterwards.")
 (defvar exwm-workspace--window-y-offset 0
   "Offset between Emacs first window & outer frame in Y.")
 
-(defvar exwm-input--during-command)
 (defvar exwm-input--event-hook)
 (defvar exwm-layout-show-all-buffers)
 (defvar exwm-manage--desktop)
@@ -1284,7 +1283,7 @@ ALIST is an action alist, as accepted by function `display-buffer'."
     (exwm-workspace--update-minibuffer-height t)
     (exwm-workspace--show-minibuffer)
     (unless (or (not exwm-workspace-display-echo-area-timeout)
-                exwm-input--during-command ;e.g. read-event
+                real-this-command ;e.g. read-event
                 input-method-use-echo-area)
       (setq exwm-workspace--display-echo-area-timer
             (run-with-timer exwm-workspace-display-echo-area-timeout nil


### PR DESCRIPTION
`exwm-input--duration-command' isn't reliably unset when exiting commands initiated by emacsclient causing Emacs to swallow one key press. See ch11ng/exwm#253 and emacs-exwm/exwm#93.

However, `exwm-input--duration-command' appears to be no longer necessary now that bind `exwm-input-line-mode-passthrough' around all input commands (via advice).

fixes #93

* exwm-core.el (exwm--kmacro-map): remove obsolete comment.
* exwm-input.el (exwm-input--during-command): Remove variable. (exwm-input--event-passthrough-p): Remove reference to variable. (exwm-input-pre-post-command-blacklist): Remove newly unused option. (exwm-input--on-pre-command, exwm-input--on-post-command): Remove hooks. (exwm-input--init, exwm-input--exit): Remove references to the above hooks.
* exwm-workspace.el (exwm-input--during-command): Remove reference to removed variable.
(exwm-workspace--on-echo-area-dirty): Use real-this-command to detect in-progress commands.