### PR TITLE
Reduce autoloads

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -564,7 +564,6 @@ Notes:
          (when exwm--connection
            (exwm-input--update-global-prefix-keys))))
 
-;;;###autoload
 (defun exwm-input-set-key (key command)
   "Set a global KEY binding to COMMAND.
 
@@ -840,7 +839,6 @@ button event."
           (setq exwm--input-mode 'char-mode)
           (run-hooks 'exwm-input-input-mode-change-hook))))))
 
-;;;###autoload
 (defun exwm-input-grab-keyboard (&optional id)
   "Switch to `line-mode`.
 When ID is non-nil, grab key events on its corresponding window."
@@ -852,7 +850,6 @@ When ID is non-nil, grab key events on its corresponding window."
     (exwm-input--grab-keyboard id)
     (exwm-input--update-mode-line id)))
 
-;;;###autoload
 (defun exwm-input-release-keyboard (&optional id)
   "Switch to `char-mode`.
 When ID is non-nil, release keyboard events on its corresponding window."
@@ -864,7 +861,6 @@ When ID is non-nil, release keyboard events on its corresponding window."
     (exwm-input--release-keyboard id)
     (exwm-input--update-mode-line id)))
 
-;;;###autoload
 (defun exwm-input-toggle-keyboard (&optional id)
   "Toggle between `line-mode' and `char-mode'.
 When ID is non-nil, toggle in its correpsonding window."
@@ -908,7 +904,6 @@ When ID is non-nil, toggle in its correpsonding window."
                                    exwm--connection)))))
     (xcb:flush exwm--connection)))
 
-;;;###autoload
 (cl-defun exwm-input-send-next-key (n &optional end-key)
   "Send next N keys to client window.
 N is currently capped at 12.
@@ -1024,7 +1019,6 @@ Notes:
     (when (> (length keys) 1)
       (substring keys 0 -1))))
 
-;;;###autoload
 (defun exwm-input-set-simulation-key (original-key simulated-key)
   "Set ORIGINAL-KEY to  SIMULATED-KEY.
 
@@ -1068,7 +1062,6 @@ where both ORIGINAL-KEY and SIMULATED-KEY are key sequences."
   (let ((exwm-input--local-simulation-keys t))
     (exwm-input--set-simulation-keys simulation-keys)))
 
-;;;###autoload
 (cl-defun exwm-input-send-simulation-key (n)
   "Fake N key events according to the last input key sequence."
   (interactive "p")
@@ -1081,7 +1074,6 @@ where both ORIGINAL-KEY and SIMULATED-KEY are key sequences."
       (dolist (key keys)
         (exwm-input--fake-key key)))))
 
-;;;###autoload
 (defmacro exwm-input-invoke-factory (keys)
   "Make a command that invokes KEYS when called.
 

--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -187,7 +187,6 @@ See variable `exwm-layout-auto-iconify'."
       (exwm-layout--auto-iconify)
       (xcb:flush exwm--connection))))
 
-;;;###autoload
 (cl-defun exwm-layout-set-fullscreen (&optional id)
   "Make window ID fullscreen."
   (interactive)
@@ -213,7 +212,6 @@ See variable `exwm-layout-auto-iconify'."
     (set-window-dedicated-p (get-buffer-window) t)
     (exwm-input--release-keyboard exwm--id)))
 
-;;;###autoload
 (cl-defun exwm-layout-unset-fullscreen (&optional id)
   "Restore X window ID from fullscreen state."
   (interactive)
@@ -244,7 +242,6 @@ See variable `exwm-layout-auto-iconify'."
     (when (eq 'line-mode exwm--selected-input-mode)
       (exwm-input--grab-keyboard exwm--id))))
 
-;;;###autoload
 (defun exwm-layout-toggle-fullscreen (&optional id)
   "Toggle fullscreen mode of X window ID.
 If ID is non-nil, default to ID of `window-buffer'."
@@ -434,7 +431,6 @@ If DIRTY is non-nil, refresh layout immediately."
           (exwm-layout--refresh exwm-workspace--current)
         (exwm--defer 0 #'exwm-layout--refresh exwm-workspace--current)))))
 
-;;;###autoload
 (defun exwm-layout-enlarge-window (delta &optional horizontal)
   "Make the selected window DELTA pixels taller.
 
@@ -524,7 +520,6 @@ windows."
                            :height height))
         (xcb:flush exwm--connection))))))
 
-;;;###autoload
 (defun exwm-layout-enlarge-window-horizontally (delta)
   "Make the selected window DELTA pixels wider.
 
@@ -533,7 +528,6 @@ See also `exwm-layout-enlarge-window'."
   (exwm--log "%s" delta)
   (exwm-layout-enlarge-window delta t))
 
-;;;###autoload
 (defun exwm-layout-shrink-window (delta)
   "Make the selected window DELTA pixels lower.
 
@@ -542,7 +536,6 @@ See also `exwm-layout-enlarge-window'."
   (exwm--log "%s" delta)
   (exwm-layout-enlarge-window (- delta)))
 
-;;;###autoload
 (defun exwm-layout-shrink-window-horizontally (delta)
   "Make the selected window DELTA pixels narrower.
 
@@ -551,7 +544,6 @@ See also `exwm-layout-enlarge-window'."
   (exwm--log "%s" delta)
   (exwm-layout-enlarge-window (- delta) t))
 
-;;;###autoload
 (defun exwm-layout-hide-mode-line ()
   "Hide mode-line."
   (interactive)
@@ -570,7 +562,6 @@ See also `exwm-layout-enlarge-window'."
                              mode-line-height)
                           nil t)))))
 
-;;;###autoload
 (defun exwm-layout-show-mode-line ()
   "Show mode-line."
   (interactive)
@@ -588,7 +579,6 @@ See also `exwm-layout-enlarge-window'."
       (call-interactively #'exwm-input-grab-keyboard))
     (force-mode-line-update)))
 
-;;;###autoload
 (defun exwm-layout-toggle-mode-line ()
   "Toggle the display of mode-line."
   (interactive)

--- a/exwm-randr.el
+++ b/exwm-randr.el
@@ -212,7 +212,6 @@ In a mirroring setup some monitors overlap and should be treated as one."
                                             monitor-alias-alist))))))
     monitor-alias-alist))
 
-;;;###autoload
 (defun exwm-randr-refresh ()
   "Refresh workspaces according to the updated RandR info."
   (interactive)

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -294,7 +294,6 @@ Show PROMPT to the user if non-nil."
                 sequence ""))
              sequence)))))
 
-;;;###autoload
 (defun exwm-workspace--get-geometry (frame)
   "Return the geometry of frame FRAME."
   (or (frame-parameter frame 'exwm-geometry)
@@ -304,7 +303,6 @@ Show PROMPT to the user if non-nil."
                      :width (x-display-pixel-width)
                      :height (x-display-pixel-height))))
 
-;;;###autoload
 (defun exwm-workspace--current-height ()
   "Return the height of current workspace."
   (let ((geometry (frame-parameter exwm-workspace--current 'exwm-geometry)))
@@ -312,7 +310,6 @@ Show PROMPT to the user if non-nil."
         (slot-value geometry 'height)
       (x-display-pixel-height))))
 
-;;;###autoload
 (defun exwm-workspace--minibuffer-own-frame-p ()
   "Reports whether the minibuffer is displayed in its own frame."
   (memq exwm-workspace-minibuffer-position '(top bottom)))
@@ -560,7 +557,6 @@ PREFIX-DIGITS is a list of the digits introduced so far."
   (goto-history-element (1+ n))
   (exit-minibuffer))
 
-;;;###autoload
 (defun exwm-workspace-switch (frame-or-index &optional force)
   "Switch to workspace FRAME-OR-INDEX (0-based).
 
@@ -692,7 +688,6 @@ When FORCE is true, allow switching to current workspace."
     (funcall exwm-workspace--original-handle-focus-in (list 'focus-in frame))
     (run-hooks 'exwm-workspace-switch-hook)))
 
-;;;###autoload
 (defun exwm-workspace-switch-create (frame-or-index)
   "Switch to workspace FRAME-OR-INDEX creating it first non-existent.
 
@@ -717,7 +712,6 @@ Passing a workspace frame as the first option is for internal use only."
       (run-hooks 'exwm-workspace-list-change-hook))
     (exwm-workspace-switch frame-or-index)))
 
-;;;###autoload
 (defun exwm-workspace-swap (workspace1 workspace2)
   "Interchange position of WORKSPACE1 with that of WORKSPACE2."
   (interactive
@@ -753,7 +747,6 @@ Passing a workspace frame as the first option is for internal use only."
         (exwm-workspace-switch exwm-workspace--current t))
       (run-hooks 'exwm-workspace-list-change-hook))))
 
-;;;###autoload
 (defun exwm-workspace-move (workspace nth)
   "Move WORKSPACE to the NTH position.
 
@@ -800,7 +793,6 @@ before it."
         (exwm-workspace-switch exwm-workspace--current t))
       (run-hooks 'exwm-workspace-list-change-hook))))
 
-;;;###autoload
 (defun exwm-workspace-add (&optional index)
   "Add a workspace as the INDEX-th workspace, or the last one if INDEX is nil.
 
@@ -813,7 +805,6 @@ INDEX must not exceed the current number of workspaces."
       (exwm-workspace-move (make-frame) index)
     (make-frame)))
 
-;;;###autoload
 (defun exwm-workspace-delete (&optional frame-or-index)
   "Delete the workspace FRAME-OR-INDEX."
   (interactive)
@@ -841,7 +832,6 @@ INDEX must not exceed the current number of workspaces."
                          :window id
                          :data desktop)))))
 
-;;;###autoload
 (cl-defun exwm-workspace-move-window (frame-or-index &optional id)
   "Move window ID to workspace FRAME-OR-INDEX."
   (interactive (list
@@ -983,7 +973,6 @@ INDEX must not exceed the current number of workspaces."
         (xcb:flush exwm--connection)))
     (setq exwm-workspace--switch-history-outdated t)))
 
-;;;###autoload
 (defun exwm-workspace-switch-to-buffer (buffer-or-name)
   "Make selected window display BUFFER-OR-NAME."
   (interactive
@@ -1075,7 +1064,6 @@ Please check `exwm-workspace--minibuffer-own-frame-p' first."
   (assq (frame-parameter exwm-workspace--minibuffer 'exwm-container)
         exwm-workspace--id-struts-alist))
 
-;;;###autoload
 (defun exwm-workspace-attach-minibuffer ()
   "Attach the minibuffer making it always visible."
   (interactive)
@@ -1100,7 +1088,6 @@ Please check `exwm-workspace--minibuffer-own-frame-p' first."
       (dolist (f exwm-workspace--list)
         (exwm-workspace--set-fullscreen f)))))
 
-;;;###autoload
 (defun exwm-workspace-detach-minibuffer ()
   "Detach the minibuffer so that it automatically hides."
   (interactive)
@@ -1118,7 +1105,6 @@ Please check `exwm-workspace--minibuffer-own-frame-p' first."
         (exwm-workspace--set-fullscreen f))
       (exwm-workspace--hide-minibuffer))))
 
-;;;###autoload
 (defun exwm-workspace-toggle-minibuffer ()
   "Attach the minibuffer if it's detached, or detach it if it's attached."
   (interactive)

--- a/exwm.el
+++ b/exwm.el
@@ -141,7 +141,6 @@ Set during `exwm-init'.")
       (exwm-layout--refresh)
       (call-interactively #'exwm-input-grab-keyboard))))
 
-;;;###autoload
 (defun exwm-restart ()
   "Restart EXWM."
   (interactive)
@@ -909,7 +908,6 @@ manager.  If t, replace it, if nil, abort and ask the user if `ask'."
         (xcb:+request exwm--connection se))
       (setq exwm--wmsn-window new-owner))))
 
-;;;###autoload
 (cl-defun exwm-init (&optional frame)
   "Initialize EXWM.
 FRAME, if given, indicates the X display EXWM should manage."
@@ -987,7 +985,6 @@ FRAME, if given, indicates the X display EXWM should manage."
      (warn "[EXWM] EXWM fails to start (%s: %s)" (car err) (cdr err)))))
 
 
-;;;###autoload
 (defun exwm-exit ()
   "Exit EXWM."
   (interactive)


### PR DESCRIPTION
Only entry points to EXWM are marked as autoloaded. These are the functions `exwm-enable` and `exwm-*-mode`.

See #102 