### PR TITLE
exwm-enable: Set environment variables and x-no-window-manager

### DIFF
--- a/exwm.el
+++ b/exwm.el
@@ -1002,6 +1002,7 @@ FRAME, if given, indicates the X display EXWM should manage."
     (xcb:disconnect exwm--connection))
   (setq exwm--connection nil)
   (setq exwm--terminal nil)
+  (setenv "INSIDE_EXWM" nil)
   (exwm--log "Exited"))
 
 ;;;###autoload
@@ -1025,6 +1026,7 @@ Optional argument UNDO may be either of the following symbols:
      (setq frame-resize-pixelwise t     ;mandatory; before init
            window-resize-pixelwise t
            x-no-window-manager t)
+     (setenv "INSIDE_EXWM" "1")
      ;; Ignore unrecognized command line arguments.  This can be helpful
      ;; when EXWM is launched by some session manager.
      (push #'vector command-line-functions)


### PR DESCRIPTION
    exwm-enable: Set environment variables and x-no-window-manager
    
    * exwm.el (exwm-enable): Set environment variables XDG_CURRENT_DESKTOP and
    XDG_SESSION_DESKTOP such that EXWM can be detected inside nested Emacs sessions.
    Furthermore set `x-no-window-manager' which tells Emacs to not wait for the
    window manager, which with EXWM, is itself.
