### PR TITLE
Use defvar-keymap and keymap-set instead of define-key

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -283,40 +283,38 @@ One of `line-mode' or `char-mode'.")
 ;; _MOTIF_WM_HINTS
 (defvar-local exwm--mwm-hints-decorations t)
 
-(defvar exwm-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map "\C-c\C-d\C-l" #'xcb-debug:clear)
-    (define-key map "\C-c\C-d\C-m" #'xcb-debug:mark)
-    (define-key map "\C-c\C-d\C-t" #'exwm-debug-mode)
-    (define-key map "\C-c\C-f" #'exwm-layout-set-fullscreen)
-    (define-key map "\C-c\C-h" #'exwm-floating-hide)
-    (define-key map "\C-c\C-k" #'exwm-input-release-keyboard)
-    (define-key map "\C-c\C-m" #'exwm-workspace-move-window)
-    (define-key map "\C-c\C-q" #'exwm-input-send-next-key)
-    (define-key map "\C-c\C-t\C-f" #'exwm-floating-toggle-floating)
-    (define-key map "\C-c\C-t\C-m" #'exwm-layout-toggle-mode-line)
-    map)
-  "Keymap for `exwm-mode'.")
+(defvar-keymap exwm-mode-map
+  :doc "Keymap for `exwm-mode'."
+  "C-c C-d C-l" #'xcb-debug:clear
+  "C-c C-d C-m" #'xcb-debug:mark
+  "C-c C-d C-t" #'exwm-debug-mode
+  "C-c C-f" #'exwm-layout-set-fullscreen
+  "C-c C-h" #'exwm-floating-hide
+  "C-c C-k" #'exwm-input-release-keyboard
+  "C-c C-m" #'exwm-workspace-move-window
+  "C-c C-q" #'exwm-input-send-next-key
+  "C-c C-t C-f" #'exwm-floating-toggle-floating
+  "C-c C-t C-m" #'exwm-layout-toggle-mode-line)
 
-(defvar exwm--kmacro-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map [t]
-      (lambda ()
-        (interactive)
-        (cond
-         ((or exwm-input-line-mode-passthrough
-              (active-minibuffer-window)
-              (memq last-input-event exwm-input--global-prefix-keys)
-              (memq last-input-event exwm-input-prefix-keys)
-              (lookup-key exwm-mode-map (vector last-input-event))
-              (gethash last-input-event exwm-input--simulation-keys))
-          (set-transient-map (make-composed-keymap (list exwm-mode-map
-                                                         global-map)))
-          (push last-input-event unread-command-events))
-         (t
-          (exwm-input--fake-key last-input-event)))))
-    map)
-  "Keymap used when executing keyboard macros.")
+(defun exwm--kmacro-self-insert-command ()
+  "The EXWM kmacro equivalent of `self-insert-command'."
+  (interactive)
+  (cond
+   ((or exwm-input-line-mode-passthrough
+        (active-minibuffer-window)
+        (memq last-input-event exwm-input--global-prefix-keys)
+        (memq last-input-event exwm-input-prefix-keys)
+        (lookup-key exwm-mode-map (vector last-input-event))
+        (gethash last-input-event exwm-input--simulation-keys))
+    (set-transient-map (make-composed-keymap (list exwm-mode-map global-map)))
+    (push last-input-event unread-command-events))
+   (t
+    (exwm-input--fake-key last-input-event))))
+(put 'exwm--kmacro-self-insert-command 'completion-predicate #'ignore)
+
+(defvar-keymap exwm--kmacro-map
+  :doc "Keymap used when executing keyboard macros."
+  "<t>" #'exwm--kmacro-self-insert-command)
 
 ;; This menu mainly acts as an reminder for users.  Thus it should be as
 ;; detailed as possible, even some entries do not make much sense here.

--- a/exwm-workspace.el
+++ b/exwm-workspace.el
@@ -175,12 +175,12 @@ FRAME may be either a workspace frame or a workspace position."
 (defun exwm-workspace--init-switch-map ()
   "Initialize variable `exwm-workspace--switch-map'."
   (let ((map (make-sparse-keymap)))
-    (define-key map [t] (lambda () (interactive)))
-    (define-key map "+" #'exwm-workspace--prompt-add)
-    (define-key map "-" #'exwm-workspace--prompt-delete)
+    (keymap-set map "<t>" #'ignore)
+    (keymap-set map "+" #'exwm-workspace--prompt-add)
+    (keymap-set map "-" #'exwm-workspace--prompt-delete)
     (dotimes (i 10)
-      (define-key map (int-to-string i)
-        #'exwm-workspace--switch-map-nth-prefix))
+      (keymap-set map (int-to-string i)
+                  #'exwm-workspace--switch-map-nth-prefix))
     (unless (eq exwm-workspace-index-map #'number-to-string)
       ;; Add extra (and possibly override) keys for selecting workspace.
       (dotimes (i 10)
@@ -188,25 +188,25 @@ FRAME may be either a workspace frame or a workspace position."
           (when (and (stringp key)
                      (= (length key) 1)
                      (<= 0 (elt key 0) 127))
-            (define-key map key
-              (lambda ()
-                (interactive)
-                (exwm-workspace--switch-map-select-nth i)))))))
-    (define-key map "\C-a" (lambda () (interactive) (goto-history-element 1)))
-    (define-key map "\C-e" (lambda ()
-                             (interactive)
-                             (goto-history-element (exwm-workspace--count))))
-    (define-key map "\C-g" #'abort-recursive-edit)
-    (define-key map "\C-]" #'abort-recursive-edit)
-    (define-key map "\C-j" #'exit-minibuffer)
-    ;; (define-key map "\C-m" #'exit-minibuffer) ;not working
-    (define-key map [return] #'exit-minibuffer)
-    (define-key map " " #'exit-minibuffer)
-    (define-key map "\C-f" #'previous-history-element)
-    (define-key map "\C-b" #'next-history-element)
+            (keymap-set map key
+                        (lambda ()
+                          (interactive)
+                          (exwm-workspace--switch-map-select-nth i)))))))
+    (keymap-set map "C-a" (lambda () (interactive) (goto-history-element 1)))
+    (keymap-set map "C-e" (lambda ()
+                            (interactive)
+                            (goto-history-element (exwm-workspace--count))))
+    (keymap-set map "C-g" #'abort-recursive-edit)
+    (keymap-set map "C-]" #'abort-recursive-edit)
+    (keymap-set map "C-j" #'exit-minibuffer)
+    ;; (keymap-set map "\C-m" #'exit-minibuffer) ;not working
+    (keymap-set map "<return>" #'exit-minibuffer)
+    (keymap-set map "<space>" #'exit-minibuffer)
+    (keymap-set map "C-f" #'previous-history-element)
+    (keymap-set map "C-b" #'next-history-element)
     ;; Alternative keys
-    (define-key map [right] #'previous-history-element)
-    (define-key map [left] #'next-history-element)
+    (keymap-set map "<right>" #'previous-history-element)
+    (keymap-set map "<left>" #'next-history-element)
     (setq exwm-workspace--switch-map map)))
 
 (defun exwm-workspace--workspace-from-frame-or-index (frame-or-index)
@@ -543,9 +543,9 @@ PREFIX-DIGITS is a list of the digits introduced so far."
                      (interactive)
                      (exwm-workspace--switch-map-nth-prefix digits)))))
          (dotimes (i 10)
-           (define-key map (int-to-string i) cmd))
+           (keymap-set map (int-to-string i) cmd))
          ;; Accept
-         (define-key map [return]
+         (keymap-set map "<return>"
            (lambda ()
              (interactive)
              (exwm-workspace--switch-map-select-nth n)))


### PR DESCRIPTION
Emacs 29+ encourages these functions over define-key, so use them. We still use define-key in simulation keys because we need to process raw key definitions (vectors, not strings).

* exwm-core.el (exwm-mode-map, exwm--kmacro-map): Use defvar-keymap. (exwm--kmacro-self-insert-command): change the kmacro self-insert command from a lambda to a function.
* exwm-workspace.el (exwm-workspace--init-switch-map): Use keymap-set. (exwm-workspace--switch-map-nth-prefix): Use keymap-set.