### PR TITLE
Work around a bug where the tab-line isn't taken into account

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -117,6 +117,8 @@ See variable `exwm-layout-auto-iconify'."
          (width (- (pop edges) x))
          (height (- (pop edges) y))
          frame-x frame-y frame-width frame-height)
+    (when (eval-when-compile (< emacs-major-version 31))
+      (setq y (+ y (window-tab-line-height window))))
     (with-current-buffer (exwm--id->buffer id)
       (when exwm--floating-frame
         (setq frame-width (frame-pixel-width exwm--floating-frame)


### PR DESCRIPTION
In Emacs before version 31, window-inside-absolute-pixel-edges returns the wrong y-offset when the per-buffer tab-line is enabled. The tab-line is taken into account when computing the window's height, so we adjust the y-offset after computing the height.

Fixed upstream in https://debbugs.gnu.org/cgi/bugreport.cgi?bug=75576.

* exwm-layout.el (exwm-layout--show): Adjust the window's y-offset to include the tab-line.  (Bug emacs-exwm/exwm#114)