### PR TITLE
Check Emacs version at runtime as well

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -117,7 +117,7 @@ See variable `exwm-layout-auto-iconify'."
          (width (- (pop edges) x))
          (height (- (pop edges) y))
          frame-x frame-y frame-width frame-height)
-    (when (eval-when-compile (< emacs-major-version 31))
+    (when (< emacs-major-version 31)
       (setq y (+ y (window-tab-line-height window))))
     (with-current-buffer (exwm--id->buffer id)
       (when exwm--floating-frame


### PR DESCRIPTION
Checking only at compile time would lead to bugs when the user upgrades
to a new Emacs version, and the cost of checking at runtime is
negligible.

* exwm-layout.el (exwm-layout--show): check version at runtime.