### PR TITLE
Add a customise option to not grab the keyboard in full screen mode.

### DIFF
--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -35,6 +35,11 @@
   "Non-nil to automatically iconify unused X windows when possible."
   :type 'boolean)
 
+(defcustom exwm-layout-fullscreen-release-keyboard t
+  "Non-nil to release the keyboard (enter char-mode) when an application is full-screen.
+That is, when t, Emacs won't intercept keys sent to fullscreen applications."
+  :type 'boolean)
+
 (defcustom exwm-layout-show-all-buffers nil
   "Non-nil to allow switching to buffers on other workspaces."
   :type 'boolean)
@@ -203,7 +208,8 @@ See variable `exwm-layout-auto-iconify'."
     (exwm-layout--set-ewmh-state exwm--id)
     (xcb:flush exwm--connection)
     (set-window-dedicated-p (get-buffer-window) t)
-    (exwm-input--release-keyboard exwm--id)))
+    (when exwm-layout-fullscreen-release-keyboard
+      (exwm-input--release-keyboard exwm--id))))
 
 (cl-defun exwm-layout-unset-fullscreen (&optional id)
   "Restore X window ID from fullscreen state."


### PR DESCRIPTION
Especially when using multiple monitors, I am not a fan of EXWM automatically switching X windows to `char mode` upon entering full screen. I understand the reasoning and think it should remain the default, since the unprepared user might otherwise accidentally open an invisible `M-x` menu behind their video player and become very sad.

However, I would argue that users who know what they are doing should have the option of staying in `line mode`. Personally, I often have a full screen video player or game running on one monitor while also using a chat client on another monitor, and if the game is in char mode, I cannot use my regular keybinds to quickly reply to chat messages. I do not want to add those keybinds to `exwm-input-global-keys` since that would mess up my workflow in windows where I enter `char mode` on purpose.

I think adding a customise option for this is a small change that has a benefit for at least some users at essentially no performance impact.

PS: Please let me know if in the future I should open an issue first rather than creating a pull request immediately.