### PR TITLE
Correctly account for the tab-line on Emacs <= 30 (everywhere)

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -124,6 +124,32 @@ FORMAT-STRING is a string specifying the message to output, as in
                         ,@objects)
      nil))
 
+(defalias 'exwm--window-inside-absolute-pixel-edges
+  (if (< emacs-major-version 31)
+      (lambda (&optional window)
+        (let* ((window (window-normalize-window window t))
+               (edges (window-inside-absolute-pixel-edges window))
+               (tab-line-height (window-tab-line-height window)))
+          (cl-incf (elt edges 1) tab-line-height)
+          (cl-incf (elt edges 3) tab-line-height)
+          edges))
+    #'window-inside-absolute-pixel-edges)
+  "A fixed implementation of `window-inside-absolute-pixel-edges'.
+This version correctly handles tab-lines on Emacs prior to v31.1.")
+
+(defalias 'exwm--window-inside-pixel-edges
+  (if (< emacs-major-version 31)
+      (lambda (&optional window)
+        (let* ((window (window-normalize-window window t))
+               (edges (window-inside-pixel-edges window))
+               (tab-line-height (window-tab-line-height window)))
+          (cl-incf (elt edges 1) tab-line-height)
+          (cl-incf (elt edges 3) tab-line-height)
+          edges))
+    #'window-inside-pixel-edges)
+  "A fixed implementation of `window-inside-pixel-edges'.
+This version correctly handles tab-lines on Emacs prior to v31.1.")
+
 (defsubst exwm--id->buffer (id)
   "X window ID => Emacs buffer."
   (declare (indent defun))

--- a/exwm-floating.el
+++ b/exwm-floating.el
@@ -194,7 +194,7 @@ If TILED-P is non-nil, set actions for tiled window."
         (let ((buffer (exwm--id->buffer exwm-transient-for))
               window edges)
           (when (and buffer (setq window (get-buffer-window buffer)))
-            (setq edges (window-inside-absolute-pixel-edges window))
+            (setq edges (exwm--window-inside-absolute-pixel-edges window))
             (unless (and (<= width (- (elt edges 2) (elt edges 0)))
                          (<= height (- (elt edges 3) (elt edges 1))))
               (setq edges nil)))
@@ -256,7 +256,7 @@ If TILED-P is non-nil, set actions for tiled window."
     ;; timely.
     ;; The frame will be made visible by `select-frame-set-input-focus'.
     (make-frame-invisible frame)
-    (let* ((edges (window-inside-pixel-edges window))
+    (let* ((edges (exwm--window-inside-pixel-edges window))
            (frame-width (+ width (- (frame-pixel-width frame)
                                     (- (elt edges 2) (elt edges 0)))))
            (frame-height (+ height (- (frame-pixel-height frame)
@@ -751,7 +751,7 @@ Both DELTA-X and DELTA-Y default to 1.  This command should be bound locally."
            (geometry (xcb:+request-unchecked+reply exwm--connection
                          (make-instance 'xcb:GetGeometry
                                         :drawable floating-container)))
-           (edges (window-inside-absolute-pixel-edges)))
+           (edges (exwm--window-inside-absolute-pixel-edges)))
       (with-slots (x y) geometry
         (exwm--set-geometry floating-container
                             (+ x delta-x) (+ y delta-y) nil nil))

--- a/exwm-input.el
+++ b/exwm-input.el
@@ -265,7 +265,7 @@ ARGS are additional arguments to CALLBACK."
                 ;; The floating X window is on another workspace.
                 (exwm-workspace-switch exwm--frame)))))
         ;; Send a fake MotionNotify event to Emacs.
-        (setq edges (window-inside-pixel-edges window)
+        (setq edges (exwm--window-inside-pixel-edges window)
               fake-evt (make-instance 'xcb:MotionNotify
                                       :detail 0
                                       :time time

--- a/exwm-layout.el
+++ b/exwm-layout.el
@@ -111,14 +111,12 @@ See variable `exwm-layout-auto-iconify'."
 (defun exwm-layout--show (id &optional window)
   "Show window ID exactly fit in the Emacs window WINDOW."
   (exwm--log "Show #x%x in %s" id window)
-  (let* ((edges (window-inside-absolute-pixel-edges window))
+  (let* ((edges (exwm--window-inside-absolute-pixel-edges window))
          (x (pop edges))
          (y (pop edges))
          (width (- (pop edges) x))
          (height (- (pop edges) y))
          frame-x frame-y frame-width frame-height)
-    (when (< emacs-major-version 31)
-      (setq y (+ y (window-tab-line-height window))))
     (with-current-buffer (exwm--id->buffer id)
       (when exwm--floating-frame
         (setq frame-width (frame-pixel-width exwm--floating-frame)
@@ -457,7 +455,7 @@ windows."
    (exwm--fixed-size)                   ;fixed size
    (horizontal
     (let* ((width (frame-pixel-width))
-           (edges (window-inside-pixel-edges))
+           (edges (exwm--window-inside-pixel-edges))
            (inner-width (- (elt edges 2) (elt edges 0)))
            (margin (- width inner-width)))
       (if (> delta 0)
@@ -490,7 +488,7 @@ windows."
         (xcb:flush exwm--connection))))
    (t
     (let* ((height (+ (frame-pixel-height) exwm-workspace--frame-y-offset))
-           (edges (window-inside-pixel-edges))
+           (edges (exwm--window-inside-pixel-edges))
            (inner-height (- (elt edges 3) (elt edges 1)))
            (margin (- height inner-height)))
       (if (> delta 0)

--- a/exwm-manage.el
+++ b/exwm-manage.el
@@ -664,7 +664,7 @@ border-width: %d; sibling: #x%x; stack-mode: %d"
                      (or (not exwm--floating-frame)
                          (progn
                            (setq edges
-                                 (window-inside-pixel-edges
+                                 (exwm--window-inside-pixel-edges
                                   (get-buffer-window buffer t))
                                  width-delta (- width (- (elt edges 2)
                                                          (elt edges 0)))
@@ -688,7 +688,7 @@ border-width: %d; sibling: #x%x; stack-mode: %d"
                       (with-slots (x y width height)
                           (exwm-workspace--get-geometry exwm--frame)
                         (list x y width height))
-                    (window-inside-absolute-pixel-edges
+                    (exwm--window-inside-absolute-pixel-edges
                      (get-buffer-window buffer t))))
             (exwm--log "Reply with ConfigureNotify (edges): %s" edges)
             (xcb:+request exwm--connection


### PR DESCRIPTION
9cdfe95066 (Bug emacs-exwm/exwm#114) partially fixed this but it left quite a few calls to the buggy window edge calculation function.

* exwm-core.el (exwm--window-inside-absolute-pixel-edges): Add new `exwm--window-inside(-absolute)-pixel-edges' functions that, on Emacs < 31, wrap the built-in function and adjust the edges to account for the tab-line.
* exwm-floating.el (exwm-floating--set-floating): (exwm-floating-move):
* exwm-input.el (exwm-input--on-EnterNotify):
* exwm-layout.el (exwm-layout--show): (exwm-layout-enlarge-window):
* exwm-manage.el (exwm-manage--on-ConfigureRequest): Use the new functions instead of the built-in versions.