### PR TITLE
Use the correct frame dimensions for resize requests

### DIFF
--- a/exwm-manage.el
+++ b/exwm-manage.el
@@ -712,9 +712,9 @@ border-width: %d; sibling: #x%x; stack-mode: %d"
                                                    'exwm-outer-id)
                                   nil
                                   nil
-                                  (+ (frame-pixel-width exwm--floating-frame)
+                                  (+ (frame-outer-width exwm--floating-frame)
                                      width-delta)
-                                  (+ (frame-pixel-height exwm--floating-frame)
+                                  (+ (frame-outer-height exwm--floating-frame)
                                      height-delta)))
           (exwm--log "ConfigureWindow (preserve geometry)")
           ;; Configure the unmanaged window.


### PR DESCRIPTION
We need the frame's OUTER width/height. The "pixel" width/height may or may not include the toolbar, menu-bar, etc.

* exwm-manage.el (exwm-manage--on-ConfigureRequest): Use the frame's outer width/height.