### PR TITLE
Save/restore the full geometry when hiding/showing floating windows

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -274,7 +274,7 @@ If CONN is non-nil, use it instead of the value of the variable
 (defvar-local exwm--frame nil)            ;workspace frame
 (defvar-local exwm--floating-frame nil)   ;floating frame
 (defvar-local exwm--mode-line-format nil) ;save mode-line-format
-(defvar-local exwm--floating-frame-position nil) ;set when hidden.
+(defvar-local exwm--floating-frame-geometry nil) ;set when hidden.
 (defvar-local exwm--fixed-size nil)              ;fixed size
 (defvar-local exwm--selected-input-mode 'line-mode
   "Input mode as selected by the user.


### PR DESCRIPTION
When hiding/showing floating, save and restore the full window geometry instead of just saving the position and re-computing the window size based on the frame's inner size. This lets us remove one of the final references to `exwm-workspace--frame-y-offset'.

NOTE: We can't remove `exwm-workspace--frame-y-offset' by simply using `frame-outer-height' as suggested in the TODO as that reflects the actual size of the frame window which we set to 1-by-1 when we hide it.

* exwm-core.el (exwm--floating-frame-position): Rename to exwm--floating-frame-geometry to reflect the fact that it stores the full window geometry.
* exwm-layout.el (exwm-workspace--frame-y-offset): Remove unused variable declaration.
(exwm-layout--show): Save/restore the full floating window geometry when hiding/showing floating windows, removing any uses of exwm-workspace--frame-y-offset.