### PR TITLE
Implement X window icon support

### DIFF
--- a/exwm-core.el
+++ b/exwm-core.el
@@ -293,6 +293,7 @@ One of `line-mode' or `char-mode'.")
 (defvar-local exwm--protocols nil)
 (defvar-local exwm-state xcb:icccm:WM_STATE:NormalState "WM_STATE.")
 (defvar-local exwm--ewmh-state nil "_NET_WM_STATE.")
+(defvar-local exwm--icon nil "Application Icon (XPM string).")
 ;; _NET_WM_NORMAL_HINTS
 (defvar-local exwm--normal-hints-x nil)
 (defvar-local exwm--normal-hints-y nil)

--- a/exwm-manage.el
+++ b/exwm-manage.el
@@ -164,6 +164,7 @@ want to match against EXWM internal variables such as `exwm-title',
 (declare-function exwm--update-protocols "exwm.el" (id &optional force))
 (declare-function exwm--update-struts "exwm.el" (id))
 (declare-function exwm--update-title "exwm.el" (id))
+(declare-function exwm--update-icon "exwm.el" (id &optional force))
 (declare-function exwm--update-transient-for "exwm.el" (id &optional force))
 (declare-function exwm--update-desktop "exwm.el" (id &optional force))
 (declare-function exwm--update-window-type "exwm.el" (id &optional force))
@@ -300,6 +301,7 @@ This only works when procfs is mounted, which may not be the case on some BSDs."
       (exwm-manage--update-geometry id)
       (exwm-manage--update-mwm-hints id)
       (exwm--update-title id)
+      (exwm--update-icon id)
       (exwm--update-protocols id)
       (setq exwm--configurations (exwm-manage--get-configurations))
       ;; OverrideRedirect is not checked here.


### PR DESCRIPTION
Make it possible to:

1. Retrieve an X window's icon with `(exwm-icon ...)`.
2. Be notified when an X window's icon changes (e.g., to update the buffer title, etc.).

EXWM doesn't currently use this but I'm planning on getting support into the nerd-icons & friends packages.

Notes:

1. I'm using XPM as the image format because it's easy to convert X icons into this format, not because it's a nice format...
2. The simplest and fastest solution is actually to convert to the PAM image format then shell out to `pamtopng`, but I didn't want to depend on anything external.
3. We can make this faster by calling `x-window-property` instead of using XELB, but I wanted to keep things consistent and it's fast enough (on my machine, at least). HOWEVER, don't even _try_ to use this patch without updating XELB to the latest commit (the latest optimizations are required).
4. I don't handle multiple icon sizes and just take the first (which, as far as I can tell, is always the largest).
5. I don't properly handle ARGB and instead just treat the alpha channel as an image mask (fully transparent/opaque). I don't think this'll be an issue in practice.