### PR TITLE
Revert recent change to set-local-simulation-keys

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -1060,7 +1060,7 @@ where both ORIGINAL-KEY and SIMULATED-KEY are key sequences."
   (exwm--log)
   (make-local-variable 'exwm-input--simulation-keys)
   (use-local-map (copy-keymap exwm-mode-map))
-  (exwm-input--set-simulation-keys simulation-keys 'cache 'local))
+  (exwm-input--set-simulation-keys simulation-keys nil 'local))
 
 (cl-defun exwm-input-send-simulation-key (n)
   "Fake N key events according to the last input key sequence."


### PR DESCRIPTION
In https://github.com/emacs-exwm/exwm/commit/14b348ca0d3ce905538fcd565198ece2aee73c0e#diff-94285665bcafd9ba72e847570507be239dc8a2831a8a0b59aa318aef3da1fa70L1065-R1063 the behavior of `exwm-input-set-local-simulation-keys` was changed to pass a non-nil cache argument to `exwm-input--set-simulation-keys simulation-keys`.

This breaks local simulation keys, e.g. in my instance, my (non-emacs) terminal suddenly started interpreting various global simulation keys, even though they were excluded from its local simulation key map.