### PR TITLE
exwm-input: Fix exwm-input--on-ButtonPress

### DIFF
--- a/exwm-input.el
+++ b/exwm-input.el
@@ -420,18 +420,18 @@ attempt later."
              ;; Click to focus
              (setq fake-last-command t)
              (when-let* ((window (get-buffer-window buffer t))
-                         (_(not (eq window (selected-window))))
-                         (frame (window-frame window))
-                         (_(not (eq frame exwm-workspace--current))))
-               (if (exwm-workspace--workspace-p frame)
-                   ;; The X window is on another workspace
-                   (exwm-workspace-switch frame)
-                 (with-current-buffer buffer
-                   (when (and (derived-mode-p 'exwm-mode)
-                              (not (eq exwm--frame
-                                       exwm-workspace--current)))
-                     ;; The floating X window is on another workspace
-                     (exwm-workspace-switch exwm--frame))))
+                         (_(not (eq window (selected-window)))))
+               (when-let* ((frame (window-frame window))
+                           (_(not (eq frame exwm-workspace--current))))
+                 (if (exwm-workspace--workspace-p frame)
+                     ;; The X window is on another workspace
+                     (exwm-workspace-switch frame)
+                   (with-current-buffer buffer
+                     (when (and (derived-mode-p 'exwm-mode)
+                                (not (eq exwm--frame
+                                         exwm-workspace--current)))
+                       ;; The floating X window is on another workspace
+                       (exwm-workspace-switch exwm--frame)))))
                ;; It has been reported that the `window' may have be deleted
                (unless (window-live-p window)
                  (setq window (get-buffer-window buffer t)))


### PR DESCRIPTION
I recently updated EXWM and noticed that clicking on some X windows (notably Firefox windows) would not select the corresponding Emacs window.

I believe the cause is the `when-let*` introduced in d0b4b2aae81fba05c7f3ac2ccdaf15001d29ea3f changing the logic of `exwm-input--on-ButtonPress`. Previously, the check that `(not (eq frame exwm-workspace-current))` did not surround the logic for calling `select-window`.

(Thanks for all of your hard work maintaining EXWM! I've been a very happy user for many years now.)